### PR TITLE
fixed some exception handling bugs in campus-service campuses/buildings

### DIFF
--- a/src/main/java/com/revature/rms/campus/controllers/BuildingController.java
+++ b/src/main/java/com/revature/rms/campus/controllers/BuildingController.java
@@ -52,7 +52,7 @@ public class BuildingController {
     @GetMapping(value = "/id/{id}", produces = MediaType.APPLICATION_JSON_VALUE)
     public Building getBuildingById(@PathVariable int id) {
         if (id <= 0) {
-            throw new InvalidRequestException();
+            throw new InvalidRequestException("Id cannot be less than or equal to zero!");
         }
         Optional<Building> _building = buildingService.findById(id);
         if (!_building.isPresent()) {

--- a/src/main/java/com/revature/rms/campus/controllers/CampusController.java
+++ b/src/main/java/com/revature/rms/campus/controllers/CampusController.java
@@ -85,7 +85,7 @@ public class CampusController {
             throw new InvalidRequestException("Invalid Manager Id");
         }
         List<Campus> campus = campusService.findByStagingManagerId(id);
-        if (campus == null) {
+        if (campus.isEmpty()) {
             throw new ResourceNotFoundException("No Campuses Found.");
         }
         return campus;


### PR DESCRIPTION
Bug: GET campuses/campuses/staging-managers/id/{id} returns empty list, should return 404

Bug: GET campuses/buildings/training-managers/id/{id} always returns 404. Do no buildings have training managers?

Bug: GET campuses/buildings/id/-1 400 returned, message = "An invalid request was made", message should = "Id cannot be less than or equal to zero!"